### PR TITLE
Update responsive styles for the link tiles section

### DIFF
--- a/assets/scss/components/_link-tile.scss
+++ b/assets/scss/components/_link-tile.scss
@@ -1,7 +1,4 @@
 .link-tile {
-    max-width: 24.5%;
-    margin-right: 0.4%;
-    display: flex;
     border: solid 1px #D9DADB;
 
     &:hover,
@@ -10,10 +7,7 @@
     }
     
     a {
-        display: flex;
-        flex-direction: column;
-        align-items: stretch;
-        transition: transform 0.5s ease;
+        text-decoration: none;
         background-color:  govuk-colour("white");
         box-shadow: 0 -5px 0 0 #D9DADB inset;
         
@@ -36,21 +30,23 @@
     }
 
     img {
-        max-width: 100%;
+        width: 100%;
     }
 
     footer {
         display: flex;
         flex-direction: column;
-        flex-grow: 1;
 
         h3 {
             color: govuk-colour("blue");
         }
     }
 
-    @include govuk-media-query($until: tablet) {
-        flex: 0 0 100%;
-        max-width: 100%;
+    @media(max-width: 60.625em) {
+        flex: 0 0 48.8%;
+    }
+
+    @media(min-width: 60.626em) {
+        flex: 0 0 24%;
     }
 }

--- a/assets/scss/components/_tiles-panel.scss
+++ b/assets/scss/components/_tiles-panel.scss
@@ -1,9 +1,11 @@
 .tiles-panel {
-    justify-content: flex-start;
+  padding: govuk-spacing(8) 0;
+  
+  div {
     display: flex;
+    justify-content: space-between;
     flex-wrap: wrap;
-    
-    & > div:last-child {
-        margin-right: 0;
-      }
+    column-gap: .75%;
+    row-gap: .5em;
+  }
 }

--- a/assets/scss/pages/_homepage.scss
+++ b/assets/scss/pages/_homepage.scss
@@ -22,7 +22,6 @@
 }
 
 #internal-link-tile-profile {
-    
     padding-top: 0;
     padding-right: 0;
     padding-left: 0;

--- a/assets/scss/pages/_homepage.scss
+++ b/assets/scss/pages/_homepage.scss
@@ -16,8 +16,8 @@
     margin-right: 0;
 
     @media(min-width: 68.75em) {
-        min-width: 74%;
-        margin-right: .5em;
+        min-width: 74.8%;
+        margin-right: 0.4%;
     }
 }
 
@@ -53,6 +53,6 @@
     }
 
     @media(min-width: 68.75em) {
-        min-width: 25%;
+        width: 24.5%;
     }
 }

--- a/assets/scss/pages/_homepage.scss
+++ b/assets/scss/pages/_homepage.scss
@@ -16,8 +16,8 @@
     margin-right: 0;
 
     @media(min-width: 68.75em) {
-        min-width: 74.8%;
-        margin-right: 0.4%;
+        min-width: 75%;
+        margin-right: .8%;
     }
 }
 

--- a/server/views/components/link-tile/index.njk
+++ b/server/views/components/link-tile/index.njk
@@ -2,7 +2,7 @@
     <div class="link-tile">
         <a href="{{ params.url }}"
                 {% if params.openInNewTab %}rel="noreferrer noopener" target="_blank"{% endif %}>
-       
+
             <img src="{{ params.image }}"
                 alt="link tile image"
                 loading="lazy" />

--- a/server/views/components/tiles-panel/index.njk
+++ b/server/views/components/tiles-panel/index.njk
@@ -1,19 +1,21 @@
 {% from "../link-tile/index.njk" import linkTile %}
 
 {% macro tilesPanel(params, user) %}
-    <section class="govuk-grid-row tiles-panel govuk-width-container">
+    <section class="govuk-width-container">
         {% if params.title %}
             <h2>{{ params.title }}</h2>
         {% endif %}
 
-        {% for link in params.links %}
-            {{ linkTile ({
-                image: link.image,
-                title: link.title,
-                url: link.url,
-                description: link.description,
-                openInNewTab: link.openInNewTab
-            }) }}
-        {% endfor %}
+        <div id="tiles">
+            {% for link in params.links %}
+                {{ linkTile ({
+                    image: link.image,
+                    title: link.title,
+                    url: link.url,
+                    description: link.description,
+                    openInNewTab: link.openInNewTab
+                }) }}
+            {% endfor %}
+        </div>
     </section>
 {% endmacro %}

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -27,7 +27,7 @@
       </div>
     </section>
 
-    <div class="container-background-black govuk-!-padding-top-8 govuk-!-padding-bottom-8">
+    <div class="container-background-black tiles-panel">
       {{ tilesPanel(linksData, user) }}
     </div>
 


### PR DESCRIPTION
**Related to the following ticket:** 

https://trello.com/c/7TQxWdYx/66-launchpad-homepage-003-create-links-section-component

**Changes made:**

- Updated CSS to enable the link tile section to display correctly at various screen sizes
- Cleaned up CSS classes included within the HTML code

**Screen shots:**
<img width="1302" alt="Screenshot 2023-07-18 at 13 22 12" src="https://github.com/ministryofjustice/hmpps-launchpad/assets/104000682/8cb9b107-cb0f-4c6a-ac29-3bccc79d3fc5">

<img width="769" alt="Screenshot 2023-07-18 at 13 22 37" src="https://github.com/ministryofjustice/hmpps-launchpad/assets/104000682/d6b44dc8-36f6-4286-9a7b-69eb59fb0bd7">

<img width="477" alt="Screenshot 2023-07-18 at 13 22 50" src="https://github.com/ministryofjustice/hmpps-launchpad/assets/104000682/9e94b931-e650-48f9-ad8d-c638fd310292">
