### PR TITLE
Fix alerting for k8s in prod

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,4 +16,4 @@ generic-service:
     PRISONER_CONTACT_REGISTRY_API_URL: "https://prisoner-contact-registry.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service
+  alertSeverity: hmpps-launchpad


### PR DESCRIPTION
This should fix the alerting and any k8s alerts from prod will go to #launchpad-alerts now.