### PR TITLE
Lnp 1406

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ playwright/.cache/
 # Playwright local output
 pw-output/
 **/pw-output/
+**/.last-run.json
 
 # Playwright browser downloads
 /ms-playwright/

--- a/.gitignore
+++ b/.gitignore
@@ -142,10 +142,15 @@ appsettings.json
 # Playwright Reports and Artifacts
 playwright-report/
 **/playwright-report/
+playwright-report/index.html
 test-results/
 **/test-results/
 playwright/.cache/
 **/playwright/.cache/
+
+# Playwright local output
+pw-output/
+**/pw-output/
 
 # Playwright browser downloads
 /ms-playwright/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - hmpps
     depends_on: [redis]
     ports:
-      - "3000:3000"
+      - "3000"
     environment:
       - REDIS_HOST=redis
       - HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth

--- a/integration_tests/playwright.config.ts
+++ b/integration_tests/playwright.config.ts
@@ -1,0 +1,6 @@
+import rootConfig from '../playwright.config'
+
+export default {
+	...rootConfig,
+	testDir: './playwright/test/Features/e2e',
+}

--- a/integration_tests/playwright.config.ts
+++ b/integration_tests/playwright.config.ts
@@ -1,6 +1,6 @@
 import rootConfig from '../playwright.config'
 
 export default {
-	...rootConfig,
-	testDir: './playwright/test/Features/e2e',
+  ...rootConfig,
+  testDir: './playwright/test/Features/e2e',
 }

--- a/integration_tests/playwright/test/Features/e2e/Accessibility/launchpad_home_a11y.feature
+++ b/integration_tests/playwright/test/Features/e2e/Accessibility/launchpad_home_a11y.feature
@@ -1,0 +1,6 @@
+Feature: Launchpad Home Page Accessibility
+
+  Scenario: Home page passes accessibility checks
+    Given the user navigates to the Launchpad home page
+    When an accessibility scan is run
+    Then there should be no accessibility violations

--- a/integration_tests/playwright/test/Features/e2e/Accessibility/launchpad_home_a11y.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Accessibility/launchpad_home_a11y.spec.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import axe from 'axe-core'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Accessibility/launchpad_home_a11y.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Accessibility/launchpad_home_a11y.spec.ts
@@ -27,9 +27,7 @@ test.describe('Launchpad Home Page Accessibility @regression', () => {
       console.log(
         results.violations
           .map(violation => {
-            const nodes = violation.nodes
-              .map(node => `- ${node.target.join(', ')}\n  ${node.html}`)
-              .join('\n')
+            const nodes = violation.nodes.map(node => `- ${node.target.join(', ')}\n  ${node.html}`).join('\n')
             return `${violation.id}: ${violation.help}\n${nodes}`
           })
           .join('\n\n'),

--- a/integration_tests/playwright/test/Features/e2e/Accessibility/launchpad_home_a11y.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Accessibility/launchpad_home_a11y.spec.ts
@@ -1,0 +1,41 @@
+import dotenv from 'dotenv'
+import { test, expect } from '@playwright/test'
+import axe from 'axe-core'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+
+dotenv.config()
+
+test.describe('Launchpad Home Page Accessibility @regression', () => {
+  test.use({ bypassCSP: true })
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
+  })
+
+  test('has no detectable accessibility violations', async ({ page }) => {
+    await page.addScriptTag({ path: require.resolve('axe-core') })
+
+    const results = await page.evaluate(async () => {
+      return (window as unknown as { axe: typeof axe }).axe.run('#main-content')
+    })
+
+    const violationCount = results.violations.length
+    if (violationCount > 0) {
+      // Include violation details to make failures actionable.
+      // eslint-disable-next-line no-console
+      console.log(
+        results.violations
+          .map(violation => {
+            const nodes = violation.nodes
+              .map(node => `- ${node.target.join(', ')}\n  ${node.html}`)
+              .join('\n')
+            return `${violation.id}: ${violation.help}\n${nodes}`
+          })
+          .join('\n\n'),
+      )
+    }
+
+    expect(violationCount).toBe(0)
+  })
+})

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_InsideTime.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_InsideTime.spec.ts
@@ -1,12 +1,14 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadExternalLinksLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadExternalLinksLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
 test.describe('Launchpad External Web Links - Inside Time @regression', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
   })
 
   test('Assert that the user can see the inside time module', async ({ page }) => {

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_InsideTime.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_InsideTime.spec.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadExternalLinksLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadExternalLinksLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_NationalPrisonRadio.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_NationalPrisonRadio.spec.ts
@@ -1,12 +1,14 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadExternalLinksLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadExternalLinksLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
 test.describe('Launchpad External Web Links - National Prison Radio @regression', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
   })
   test('Assert that the user can see the National Prison Radio module', async ({ page }) => {
     const prisonRadioLink = page.locator(launchpadExternalLinksLocators.prisonRadioLink)

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_NationalPrisonRadio.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_NationalPrisonRadio.spec.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadExternalLinksLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadExternalLinksLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_Timetable.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_Timetable.spec.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_Timetable.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_Timetable.spec.ts
@@ -1,12 +1,14 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
 test.describe('Launchpad External Web Links - Content Hub @regression', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
   })
 
   test("Assert that the user can see today's events section", async ({ page }) => {

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_contenthub.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_contenthub.spec.ts
@@ -1,12 +1,14 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadExternalLinksLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadExternalLinksLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
 test.describe('Launchpad External Web Links - Content Hub @regression', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
   })
 
   test('Assert that the user can see the content hub module', async ({ page }) => {

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_contenthub.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_contenthub.spec.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadExternalLinksLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadExternalLinksLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_webapp.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_webapp.spec.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
@@ -19,6 +20,10 @@ test.describe('Launchpad Web App @regression', () => {
       try {
         // eslint-disable-next-line no-await-in-loop
         const response = await page.goto(targetUrl, { waitUntil: 'networkidle', timeout: 30000 })
+
+        // If the consent modal appears, approve it before continuing.
+        // eslint-disable-next-line no-await-in-loop
+        await acceptDataAccessModal(page)
 
         if (response) {
           // eslint-disable-next-line no-console

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_webapp.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/launchpad_webapp.spec.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/login_webapp.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/login_webapp.spec.ts
@@ -1,8 +1,10 @@
 import { test, expect } from '@playwright/test'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 const baseURL = process.env.TEST_INGRESS_URL || 'http://localhost:3000'
 
 test('User is logged in via Microsoft SSO @regression', async ({ page }) => {
   await page.goto('/')
+  await acceptDataAccessModal(page)
   await expect(page).toHaveURL(baseURL)
 })

--- a/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/login_webapp.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Launchpad_e2e/login_webapp.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 const baseURL = process.env.TEST_INGRESS_URL || 'http://localhost:3000'
 

--- a/integration_tests/playwright/test/Features/e2e/Profile_e2e/launchpad_profile.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Profile_e2e/launchpad_profile.spec.ts
@@ -1,12 +1,14 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import ProfileLocators from '../../../Framework/pages/Profile_Portal/ProfileLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
 test.describe('Launchpad Profile @regression', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
 
     const profileLink = page.locator(ProfileLocators.profileLink)
     await profileLink.click()

--- a/integration_tests/playwright/test/Features/e2e/Profile_e2e/launchpad_profile.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Profile_e2e/launchpad_profile.spec.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import ProfileLocators from '../../../Framework/pages/Profile_Portal/ProfileLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Timetable_e2e/profiles_timetable.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Timetable_e2e/profiles_timetable.spec.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import ProfileLocators from '../../../Framework/pages/Profile_Portal/ProfileLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Timetable_e2e/profiles_timetable.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Timetable_e2e/profiles_timetable.spec.ts
@@ -1,12 +1,14 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import ProfileLocators from '../../../Framework/pages/Profile_Portal/ProfileLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
 test.describe('Launchpad Profile Timetable @regression', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
   })
 
   test('Assert that the user can see the calendar module', async ({ page }) => {

--- a/integration_tests/playwright/test/Features/e2e/Timetable_e2e/timetable_e2e.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Timetable_e2e/timetable_e2e.spec.ts
@@ -2,12 +2,14 @@ import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import TimetableLocators from '../../../Framework/pages/Timetable_Portal/TimetableLocators'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
 test.describe('Launchpad Portal - Timetable @regression', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
 
     const timetableLink = page.locator(launchpadPortalLocators.timetableLink)
     await timetableLink.click()

--- a/integration_tests/playwright/test/Features/e2e/Timetable_e2e/timetable_e2e.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Timetable_e2e/timetable_e2e.spec.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import TimetableLocators from '../../../Framework/pages/Timetable_Portal/TimetableLocators'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Timetable_e2e/timetable_navigation_grid.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Timetable_e2e/timetable_navigation_grid.spec.ts
@@ -3,7 +3,7 @@ import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import TimetableLocators from '../../../Framework/pages/Timetable_Portal/TimetableLocators'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Features/e2e/Timetable_e2e/timetable_navigation_grid.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Timetable_e2e/timetable_navigation_grid.spec.ts
@@ -3,12 +3,14 @@ import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import TimetableLocators from '../../../Framework/pages/Timetable_Portal/TimetableLocators'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
 test.describe('Timetable Navigation and Grid Tests @regression', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
 
     const timetableLink = page.locator(launchpadPortalLocators.timetableLink)
     await timetableLink.click()

--- a/integration_tests/playwright/test/Features/e2e/Transactions_e2e/Transactions.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Transactions_e2e/Transactions.spec.ts
@@ -1,12 +1,14 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
+import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 
 test.describe('Launchpad Timetable @regression', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
+    await acceptDataAccessModal(page)
   })
 
   test('Assert that the user can see the calendar module', async ({ page }) => {

--- a/integration_tests/playwright/test/Features/e2e/Transactions_e2e/Transactions.spec.ts
+++ b/integration_tests/playwright/test/Features/e2e/Transactions_e2e/Transactions.spec.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { test, expect } from '@playwright/test'
 import launchpadPortalLocators from '../../../Framework/pages/LaunchPad_Portal/launchpadPortalLocators'
-import { acceptDataAccessModal } from '../../../Framework/utils/acceptDataAccessModal'
+import acceptDataAccessModal from '../../../Framework/utils/acceptDataAccessModal'
 
 dotenv.config()
 

--- a/integration_tests/playwright/test/Framework/utils/acceptDataAccessModal.ts
+++ b/integration_tests/playwright/test/Framework/utils/acceptDataAccessModal.ts
@@ -1,0 +1,26 @@
+import { Page } from '@playwright/test'
+
+export async function acceptDataAccessModal(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded')
+
+  const selector = 'button[form="form_approve"]'
+  const approveButton = page.locator(selector)
+
+  const isVisible = await approveButton.isVisible({ timeout: 15000 }).catch(() => false)
+  if (isVisible) {
+    await approveButton.click()
+    await page.waitForLoadState('networkidle')
+    return
+  }
+
+  // Fall back to frames in case the consent modal renders inside an iframe.
+  for (const frame of page.frames()) {
+    const frameButton = frame.locator(selector)
+    const frameVisible = await frameButton.isVisible({ timeout: 5000 }).catch(() => false)
+    if (frameVisible) {
+      await frameButton.click()
+      await page.waitForLoadState('networkidle')
+      return
+    }
+  }
+}

--- a/integration_tests/playwright/test/Framework/utils/acceptDataAccessModal.ts
+++ b/integration_tests/playwright/test/Framework/utils/acceptDataAccessModal.ts
@@ -14,13 +14,13 @@ export async function acceptDataAccessModal(page: Page): Promise<void> {
   }
 
   // Fall back to frames in case the consent modal renders inside an iframe.
-  for (const frame of page.frames()) {
-    const frameButton = frame.locator(selector)
-    const frameVisible = await frameButton.isVisible({ timeout: 5000 }).catch(() => false)
-    if (frameVisible) {
-      await frameButton.click()
-      await page.waitForLoadState('networkidle')
-      return
-    }
+  const frames = page.frames()
+  const frameVisibility = await Promise.all(
+    frames.map(frame => frame.locator(selector).isVisible({ timeout: 5000 }).catch(() => false)),
+  )
+  const visibleIndex = frameVisibility.findIndex(Boolean)
+  if (visibleIndex >= 0) {
+    await frames[visibleIndex].locator(selector).click()
+    await page.waitForLoadState('networkidle')
   }
 }

--- a/integration_tests/playwright/test/Framework/utils/acceptDataAccessModal.ts
+++ b/integration_tests/playwright/test/Framework/utils/acceptDataAccessModal.ts
@@ -1,6 +1,6 @@
 import { Page } from '@playwright/test'
 
-export async function acceptDataAccessModal(page: Page): Promise<void> {
+export default async function acceptDataAccessModal(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded')
 
   const selector = 'button[form="form_approve"]'
@@ -16,7 +16,12 @@ export async function acceptDataAccessModal(page: Page): Promise<void> {
   // Fall back to frames in case the consent modal renders inside an iframe.
   const frames = page.frames()
   const frameVisibility = await Promise.all(
-    frames.map(frame => frame.locator(selector).isVisible({ timeout: 5000 }).catch(() => false)),
+    frames.map(frame =>
+      frame
+        .locator(selector)
+        .isVisible({ timeout: 5000 })
+        .catch(() => false),
+    ),
   )
   const visibleIndex = frameVisibility.findIndex(Boolean)
   if (visibleIndex >= 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@types/supertest": "^7.2.0",
         "audit-ci": "^7.1.0",
         "cheerio": "^1.2.0",
+        "axe-core": "4.11.1",
         "concurrently": "^9.2.1",
         "cookie-session": "^2.1.1",
         "cypress": "^15.11.0",
@@ -6582,6 +6583,16 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "@types/supertest": "^7.2.0",
     "audit-ci": "^7.1.0",
     "cheerio": "^1.2.0",
+    "axe-core": "4.11.1",
     "concurrently": "^9.2.1",
     "cookie-session": "^2.1.1",
     "cypress": "^15.11.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,9 +17,8 @@ export default defineConfig({
   timeout: 30000,
   retries: process.env.CI ? 0 : 0, // More retries in CI
   // Grep configuration to control which tests to run
-  // By default, @regression tests are skipped unless REGRESSION=true is set
+  // When REGRESSION=true, run only @regression tests; otherwise run all tests.
   grep: process.env.REGRESSION === 'true' ? /@regression/ : undefined,
-  grepInvert: process.env.REGRESSION === 'true' ? undefined : /@regression/,
   reporter: [
     ['html', { open: 'never', outputFolder: 'playwright-report' }],
     ['list'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,8 +17,9 @@ export default defineConfig({
   timeout: 30000,
   retries: process.env.CI ? 0 : 0, // More retries in CI
   // Grep configuration to control which tests to run
-  // When REGRESSION=true, run only @regression tests; otherwise run all tests.
+  // When REGRESSION=true, run only @regression tests; otherwise skip them.
   grep: process.env.REGRESSION === 'true' ? /@regression/ : undefined,
+  grepInvert: process.env.REGRESSION === 'true' ? undefined : /@regression/,
   reporter: [
     ['html', { open: 'never', outputFolder: 'playwright-report' }],
     ['list'],


### PR DESCRIPTION
## Summary
- Added Playwright a11y coverage for the home page using axe-core with CSP bypass, scoped to `#main-content`, and improved violation logging.
- Added a data-access modal acceptance helper and integrated it across Playwright e2e tests.
- Updated Playwright config so default runs include all tests; added an `integration_tests` config shim.
- Expanded `.gitignore` to exclude Playwright outputs (`playwright-report/index.html`, `pw-output`, `.last-run.json`, etc.).

## Testing
- `REGRESSION=true npx playwright test --config playwright.config.ts`
- `npx playwright test --headed`
- `REGRESSION=true npx playwright test "integration_tests/playwright/test/Features/e2e/Accessibility/launchpad_home_a11y.spec.ts"`
- `npx playwright test` (from `integration_tests`)
- `npm run build`