### PR TITLE
Tweak external routes to appear neater in appInsights

### DIFF
--- a/server/routes/external/index.ts
+++ b/server/routes/external/index.ts
@@ -36,25 +36,27 @@ export default function routes(): Router {
     '/think-through-nutrition': () => config.externalUrls.thinkThroughNutrition,
   }
 
-  router.get(Object.keys(redirections), async (req, res) => {
-    const { idToken } = res.locals.user
-    const {
-      establishment: { agency_id: agencyId },
-      sub: prisonerId,
-    } = idToken
+  Object.entries(redirections).forEach(([path, getRedirectUrl]) => {
+    router.get(path, async (req, res) => {
+      const { idToken } = res.locals.user
+      const {
+        establishment: { agency_id: agencyId },
+        sub: prisonerId,
+      } = idToken
 
-    const establishment = getEstablishmentData(agencyId)
-    const redirectUrl = redirections[req.path](establishment)
+      const establishment = getEstablishmentData(agencyId)
+      const redirectUrl = getRedirectUrl(establishment)
 
-    logger.info(`Redirecting ${prisonerId} to ${redirectUrl}`)
+      logger.info(`Redirecting ${prisonerId} to ${redirectUrl}`)
 
-    await auditService.audit({
-      what: AUDIT_EVENTS.VIEW_EXTERNAL_PAGE,
-      idToken,
-      details: { pageUrl: req.originalUrl, redirectUrl },
+      await auditService.audit({
+        what: AUDIT_EVENTS.VIEW_EXTERNAL_PAGE,
+        idToken,
+        details: { pageUrl: req.originalUrl, redirectUrl },
+      })
+
+      res.redirect(redirectUrl)
     })
-
-    res.redirect(redirectUrl)
   })
 
   return router


### PR DESCRIPTION
The logs are appearing in app insights like

```
GET /external/manage-apps,/pin-phone,/self-service,/content-hub,/prison-radio,/inside-time,/adjudications,/incentives,/learning-and-skills,/money-and-debt,/visits,/privacy-policy,/transactions-help,/think-through-nutrition
```

as the Name of the operation

It should be

```
GET /external/manage-apps
GET /external/pin-phone
...
etc
```