### PR TITLE
Don't redirect user to autherror, instead go to sign-out

### DIFF
--- a/server/middleware/setUpPrisonerAuth.ts
+++ b/server/middleware/setUpPrisonerAuth.ts
@@ -70,7 +70,7 @@ export default function setUpPrisonerAuth() {
         req.user = user
         next()
       })
-      .catch(() => res.redirect('/autherror'))
+      .catch(() => res.redirect('/sign-out'))
   })
 
   router.use((req, res, next) => {


### PR DESCRIPTION
Should fix this error
https://mojdt.slack.com/archives/C05L4A55N81/p1787052116202149

There is no reason why we need to redirect to autherror for these users (login is out of their control)